### PR TITLE
Small fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,9 +132,9 @@ git_repository(
 
 git_repository(
     name = "android-spotlight",
-    commit = "1ba764bb9e3685947433f115120448910ef737ed",
+    commit = "ebde38335bfb56349eae57e705b611ead9addb15",
     remote = "https://github.com/oppia/android-spotlight",
-    shallow_since = "1667677977 -0500",
+    shallow_since = "1668824029 -0800",
 )
 
 # A custom fork of KotliTeX that removes resources artifacts that break the build, and updates the

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
       'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1',
       'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1',
       'org.mockito:mockito-core:2.7.22',
-      'com.github.oppia:android-spotlight:1ba764bb9e'
+      'com.github.oppia:android-spotlight:ebde38335bfb56349eae57e705b611ead9addb15'
   )
   compileOnly(
       'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2',

--- a/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
+++ b/app/src/main/java/org/oppia/android/app/player/exploration/ExplorationActivityPresenter.kt
@@ -55,7 +55,7 @@ class ExplorationActivityPresenter @Inject constructor(
   private val fontScaleConfigurationUtil: FontScaleConfigurationUtil,
   private val translationController: TranslationController,
   private val oppiaLogger: OppiaLogger,
-  private val resouceHandler: AppLanguageResourceHandler
+  private val resourceHandler: AppLanguageResourceHandler
 ) {
   private lateinit var explorationToolbar: Toolbar
   private lateinit var explorationToolbarTitle: TextView
@@ -149,10 +149,13 @@ class ExplorationActivityPresenter @Inject constructor(
 
   fun requestVoiceOverIconSpotlight(numberOfLogins: Int) {
     if (numberOfLogins >= 3) {
-      // spotlight voice-over icon after 3 logins
+      // Spotlight the voice-over icon after 3 or more logins.
       val audioPlayerSpotlightTarget = SpotlightTarget(
         binding.actionAudioPlayer,
-        resouceHandler.getStringInLocale(R.string.voiceover_icon_spotlight_hint),
+        resourceHandler.getStringInLocaleWithWrapping(
+          R.string.voiceover_icon_spotlight_hint,
+          resourceHandler.getStringInLocale(R.string.app_name)
+        ),
         SpotlightShape.Circle,
         Spotlight.FeatureCase.VOICEOVER_PLAY_ICON
       )

--- a/app/src/main/java/org/oppia/android/app/spotlight/SpotlightFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/spotlight/SpotlightFragment.kt
@@ -115,6 +115,8 @@ class SpotlightFragment : InjectableFragment(), SpotlightNavigationListener, Spo
       )
       requestSpotlight(targetAfterViewFullyDrawn)
     }
+    spotlightTarget.anchor.invalidate()
+    spotlightTarget.anchor.requestLayout()
   }
 
   /**

--- a/app/src/main/java/org/oppia/android/app/spotlight/SpotlightFragment.kt
+++ b/app/src/main/java/org/oppia/android/app/spotlight/SpotlightFragment.kt
@@ -89,7 +89,6 @@ class SpotlightFragment : InjectableFragment(), SpotlightNavigationListener, Spo
 
     internalProfileId = arguments?.getInt(PROFILE_ID_ARGUMENT_KEY) ?: -1
     calculateScreenSize()
-    checkIsRTL()
   }
 
   /**

--- a/app/src/main/java/org/oppia/android/app/spotlight/SpotlightManager.kt
+++ b/app/src/main/java/org/oppia/android/app/spotlight/SpotlightManager.kt
@@ -27,6 +27,10 @@ interface SpotlightManager {
   fun requestSpotlight(spotlightTarget: SpotlightTarget)
 
   companion object {
+    /**
+     * The tag that should be associated with fragment implementations of [SpotlightManager] so that
+     * it can be used for later retrieval.
+     */
     const val SPOTLIGHT_FRAGMENT_TAG = "SpotlightFragment"
   }
 }

--- a/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/player/exploration/ExplorationActivityTest.kt
@@ -496,6 +496,7 @@ class ExplorationActivityTest {
 
   @Test
   fun testBackButtonSpotlight_setToShowOnFirstLogin_notSeen_checkSpotlightIsShown() {
+    setUpAudioForFractionLesson()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -511,6 +512,7 @@ class ExplorationActivityTest {
         FRACTIONS_STORY_ID_0,
         FRACTIONS_EXPLORATION_ID_0
       )
+      testCoroutineDispatchers.runCurrent()
 
       onView(withText(R.string.exploration_exit_button_spotlight_hint))
         .check(matches(isDisplayed()))
@@ -520,6 +522,7 @@ class ExplorationActivityTest {
   @Test
   fun testBackButtonSpotlight_setToShowOnFirstLogin_alreadySeen_checkSpotlightIsNotShown() {
     markSpotlightSeen(Spotlight.FeatureCase.VOICEOVER_PLAY_ICON)
+    setUpAudioForFractionLesson()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -535,6 +538,7 @@ class ExplorationActivityTest {
         FRACTIONS_STORY_ID_0,
         FRACTIONS_EXPLORATION_ID_0
       )
+      testCoroutineDispatchers.runCurrent()
       onView(withId(R.id.close_target)).perform(click())
     }
 
@@ -553,6 +557,8 @@ class ExplorationActivityTest {
         FRACTIONS_STORY_ID_0,
         FRACTIONS_EXPLORATION_ID_0
       )
+      testCoroutineDispatchers.runCurrent()
+
       onView(withText(R.string.exploration_exit_button_spotlight_hint))
         .check(doesNotExist())
     }
@@ -580,7 +586,7 @@ class ExplorationActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
 
-      onView(withText(R.string.voiceover_icon_spotlight_hint))
+      onView(withText("Would you like Oppia to read for you? Tap on this button to try!"))
         .check(matches(isDisplayed()))
     }
   }
@@ -626,7 +632,7 @@ class ExplorationActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
 
-      onView(withText(R.string.voiceover_icon_spotlight_hint))
+      onView(withText("Would you like Oppia to read for you? Tap on this button to try!"))
         .check(doesNotExist())
     }
   }
@@ -634,6 +640,7 @@ class ExplorationActivityTest {
   @Test
   fun testVoiceoverIconSpotlight_setToShowAfter3rdLogin_1stLogin_checkNotShown() {
     markSpotlightSeen(Spotlight.FeatureCase.LESSONS_BACK_BUTTON)
+    setUpAudioForFractionLesson()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -651,7 +658,7 @@ class ExplorationActivityTest {
       )
       testCoroutineDispatchers.runCurrent()
 
-      onView(withText(R.string.voiceover_icon_spotlight_hint))
+      onView(withText("Would you like Oppia to read for you? Tap on this button to try!"))
         .check(doesNotExist())
     }
   }
@@ -843,6 +850,7 @@ class ExplorationActivityTest {
 
   @Test
   fun testAudioCellular_ratioExp_audioIcon_clickNegative_audioFragmentIsHidden() {
+    markAllSpotlightsSeen()
     setUpAudio()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
@@ -1849,6 +1857,7 @@ class ExplorationActivityTest {
   @Test
   @RunOn(TestPlatform.ROBOLECTRIC) // TODO(#3858): Enable for Espresso.
   fun testExpActivity_englishContentLang_showHint_explanationInEnglish() {
+    markAllSpotlightsSeen()
     updateContentLanguage(
       ProfileId.newBuilder().apply { internalId = internalProfileId }.build(),
       OppiaLanguage.ENGLISH
@@ -1888,6 +1897,7 @@ class ExplorationActivityTest {
   @Test
   @RunOn(TestPlatform.ROBOLECTRIC) // TODO(#3858): Enable for Espresso.
   fun testExpActivity_showHint_hasCorrectContentDescription() {
+    markAllSpotlightsSeen()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -1930,6 +1940,7 @@ class ExplorationActivityTest {
   @Test
   @RunOn(TestPlatform.ROBOLECTRIC) // TODO(#3858): Enable for Espresso.
   fun testExpActivity_showHint_checkExpandListIconWithScreenReader_isClickable() {
+    markAllSpotlightsSeen()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -1965,6 +1976,7 @@ class ExplorationActivityTest {
   @Test
   @RunOn(TestPlatform.ROBOLECTRIC) // TODO(#3858): Enable for Espresso.
   fun testExpActivity_showHint_checkExpandListIconWithoutScreenReader_isNotClickable() {
+    markAllSpotlightsSeen()
     launch<ExplorationActivity>(
       createExplorationActivityIntent(
         internalProfileId,
@@ -2001,6 +2013,7 @@ class ExplorationActivityTest {
   @Test
   @RunOn(TestPlatform.ROBOLECTRIC, buildEnvironments = [BuildEnvironment.BAZEL])
   fun testExpActivity_profileWithArabicContentLang_showHint_explanationInArabic() {
+    markAllSpotlightsSeen()
     updateContentLanguage(
       ProfileId.newBuilder().apply { internalId = internalProfileId }.build(),
       OppiaLanguage.ARABIC

--- a/app/src/sharedTest/java/org/oppia/android/app/spotlight/SpotlightFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/spotlight/SpotlightFragmentTest.kt
@@ -172,9 +172,7 @@ class SpotlightFragmentTest {
 
   @Test
   fun testSpotlightFragment_requestDelayedSpotlight_shouldShowSpotlight() {
-    launch<SpotlightFragmentTestActivity>(
-      createSpotlightFragmentTestActivity(context)
-    ).use {
+    launch<SpotlightFragmentTestActivity>(createSpotlightFragmentTestActivity(context)).use {
       testCoroutineDispatchers.runCurrent()
       it.onActivity { activity ->
         val spotlightTarget = SpotlightTarget(
@@ -187,6 +185,7 @@ class SpotlightFragmentTest {
         checkNotNull(
           activity.getSpotlightFragment()
         ).requestSpotlightViewWithDelayedLayout(spotlightTarget)
+        testCoroutineDispatchers.runCurrent()
       }
       onView(withText(sampleSpotlightText)).check(matches(isDisplayed()))
     }
@@ -194,9 +193,7 @@ class SpotlightFragmentTest {
 
   @Test
   fun testSpotlightFragment_markSpotlightSeen_checkSpotlightIsNotShowAgain() {
-    launch<SpotlightFragmentTestActivity>(
-      createSpotlightFragmentTestActivity(context)
-    ).use {
+    launch<SpotlightFragmentTestActivity>(createSpotlightFragmentTestActivity(context)).use {
       it.onActivity { activity ->
         val spotlightTarget = SpotlightTarget(
           activity.getSampleSpotlightTarget(),

--- a/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
+++ b/app/src/sharedTest/java/org/oppia/android/app/topic/TopicFragmentTest.kt
@@ -46,6 +46,8 @@ import org.oppia.android.app.application.testing.TestingBuildFlavorModule
 import org.oppia.android.app.devoptions.DeveloperOptionsModule
 import org.oppia.android.app.devoptions.DeveloperOptionsStarterModule
 import org.oppia.android.app.model.ProfileId
+import org.oppia.android.app.model.Spotlight.FeatureCase.FIRST_CHAPTER
+import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_LESSON_TAB
 import org.oppia.android.app.model.Spotlight.FeatureCase.TOPIC_REVISION_TAB
 import org.oppia.android.app.player.state.itemviewmodel.SplitScreenInteractionModule
 import org.oppia.android.app.recyclerview.RecyclerViewMatcher.Companion.atPositionOnView
@@ -823,7 +825,7 @@ class TopicFragmentTest {
     val profileId = ProfileId.newBuilder()
       .setInternalId(internalProfileId)
       .build()
-    spotlightStateController.markSpotlightViewed(profileId, Spotlight.FeatureCase.TOPIC_LESSON_TAB)
+    spotlightStateController.markSpotlightViewed(profileId, TOPIC_LESSON_TAB)
     testCoroutineDispatchers.runCurrent()
   }
 
@@ -831,7 +833,7 @@ class TopicFragmentTest {
     val profileId = ProfileId.newBuilder()
       .setInternalId(internalProfileId)
       .build()
-    spotlightStateController.markSpotlightViewed(profileId, Spotlight.FeatureCase.FIRST_CHAPTER)
+    spotlightStateController.markSpotlightViewed(profileId, FIRST_CHAPTER)
     testCoroutineDispatchers.runCurrent()
   }
 

--- a/instrumentation/src/java/AndroidManifest.xml
+++ b/instrumentation/src/java/AndroidManifest.xml
@@ -188,7 +188,7 @@
     <activity
       android:name=".app.topic.revisioncard.RevisionCardActivity"
       android:label="@string/revision_card_activity_title"
-      android:theme="@style/OppiaThemeWithoutActionBar" />
+      android:theme="@style/RevisionCardActivityTheme" />
     <activity android:name=".app.testing.SplashTestActivity" />
     <activity
       android:name=".app.topic.TopicActivity"


### PR DESCRIPTION
This fixes a few things I found for https://github.com/oppia/oppia-android/pull/4699, including:
- An issue where the spotlight library would overwrite Oppia Android's app name (required a fix in the library & using the new version)
- One missing KDoc in SpotlightManager
- A regex failure in ExplorationActivityPresenter
- Some dead code in SpotlightFragment
- Fixes in ExplorationActivityTest
- Fixes in SpotlightFragmentTest (fixed broken test by ensuring SpotlightFragment causes the anchor view to redraw to ensure doOnPreDraw is actually called)
- Some fixes in TopicFragmentTest
- One fix for instrumentation test builds

At this point, I think all checks will pass once the changes are merged.